### PR TITLE
[#18] EnumInitHelper error handling improvement

### DIFF
--- a/src/main/java/org/interstellarocean/terraforming/util/EnumInitHelper.java
+++ b/src/main/java/org/interstellarocean/terraforming/util/EnumInitHelper.java
@@ -36,7 +36,7 @@ class EnumInitHelper {
 
 	Supplier<AssertionError> nullMappingError(Enum<?> element) {
 		return () -> {
-			throw new AssertionError(format("Null mapping for %s", element));
+			return new AssertionError(format("Null mapping for %s", element));
 		};
 	}
 
@@ -100,7 +100,7 @@ class EnumInitHelper {
 
 	private Supplier<AssertionError> nullArgument(String argumentName) {
 		return () -> {
-			throw new AssertionError(format("Invalid use: null %s argument", argumentName));
+			return new AssertionError(format("Invalid use: null %s argument", argumentName));
 		};
 	}
 

--- a/src/test/java/org/interstellarocean/terraforming/util/EnumInitHelperAssertAllMappedTest.java
+++ b/src/test/java/org/interstellarocean/terraforming/util/EnumInitHelperAssertAllMappedTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2015 The Authors
+ *
+ * https://www.gnu.org/licenses/lgpl-3.0-standalone.html
+ */
+package org.interstellarocean.terraforming.util;
+
+import static com.googlecode.catchexception.throwable.CatchThrowable.catchThrowable;
+import static java.util.Collections.singleton;
+import static java.util.EnumSet.allOf;
+import static java.util.EnumSet.complementOf;
+import static java.util.EnumSet.of;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.interstellarocean.terraforming.util.CatchThrowableWorkaround.caughtThrowable;
+import static org.interstellarocean.terraforming.util.TestGroups.UNIT;
+
+import java.lang.Thread.State;
+import java.util.EnumMap;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * @author Dariusz Wakuliński
+ */
+@Test(groups = UNIT)
+public class EnumInitHelperAssertAllMappedTest {
+
+	private final static State TEST_ENUM = State.TIMED_WAITING;
+
+	private EnumInitHelper objectUnderTest;
+
+	@BeforeMethod
+	public void setUp() {
+		objectUnderTest = new EnumInitHelper();
+	}
+
+	public void shouldAssertAllMappedPass() {
+		// given
+		EnumMap<State, String> fullMap = new EnumMap<>(allOf(State.class).stream().collect(toMap(identity(), State::name)));
+		EnumMap<State, String> fullMapCopy = fullMap.clone();
+
+		// when
+		EnumMap<State, String> result = objectUnderTest.assertAllMapped(fullMap);
+
+		// then
+		assertThat(result).isSameAs(fullMap).isEqualTo(fullMapCopy);
+	}
+
+	public void shouldAssertAllMappedExplodeForNullArgument() {
+		// given
+		EnumMap<State, ?> nullMap = null;
+
+		// when
+		catchThrowable(objectUnderTest).assertAllMapped(nullMap);
+
+		// then
+		assertThat(caughtThrowable()).isExactlyInstanceOf(AssertionError.class).hasMessage("Invalid use: null mappings argument");
+	}
+
+	public void shouldAssertAllMappedExplodeForEmptyMap() {
+		// given
+		EnumMap<State, ?> emptyMap = new EnumMap<>(State.class);
+
+		// when
+		catchThrowable(objectUnderTest).assertAllMapped(emptyMap);
+
+		// then
+		assertThat(caughtThrowable()).isExactlyInstanceOf(AssertionError.class).hasMessage("Missing all mappings for (see stack trace for type)");
+	}
+
+	public void shouldAssertAllMappedExplodeForMissingMaping() {
+		// given
+		EnumMap<State, ?> missingMap = new EnumMap<>(complementOf(of(TEST_ENUM)).stream().collect(toMap(identity(), State::name)));
+
+		// when
+		catchThrowable(objectUnderTest).assertAllMapped(missingMap);
+
+		// then
+		assertThat(caughtThrowable()).isExactlyInstanceOf(AssertionError.class).hasMessage("Missing mapping(s) for " + singleton(TEST_ENUM));
+	}
+
+}

--- a/src/test/java/org/interstellarocean/terraforming/util/EnumInitHelperNullMappingErrorTest.java
+++ b/src/test/java/org/interstellarocean/terraforming/util/EnumInitHelperNullMappingErrorTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Authors
+ *
+ * https://www.gnu.org/licenses/lgpl-3.0-standalone.html
+ */
+package org.interstellarocean.terraforming.util;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.interstellarocean.terraforming.util.TestGroups.UNIT;
+
+import java.lang.Thread.State;
+import java.util.function.Supplier;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * @author Dariusz Wakuliński
+ */
+@Test(groups = UNIT)
+public class EnumInitHelperNullMappingErrorTest {
+
+	private final static State TEST_ENUM = State.TIMED_WAITING;
+
+	private EnumInitHelper objectUnderTest;
+
+	@BeforeMethod
+	public void setUp() {
+		objectUnderTest = new EnumInitHelper();
+	}
+
+	public void shouldNullMappingErrorReturnCorrectResult() {
+		// when
+		Supplier<AssertionError> result = objectUnderTest.nullMappingError(TEST_ENUM);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.get()).isExactlyInstanceOf(AssertionError.class).hasMessage("Null mapping for " + TEST_ENUM);
+	}
+
+}

--- a/src/test/java/org/interstellarocean/terraforming/util/EnumInitHelperSafeMapTest.java
+++ b/src/test/java/org/interstellarocean/terraforming/util/EnumInitHelperSafeMapTest.java
@@ -7,11 +7,6 @@ package org.interstellarocean.terraforming.util;
 
 import static com.googlecode.catchexception.throwable.CatchThrowable.catchThrowable;
 import static java.util.Collections.singleton;
-import static java.util.EnumSet.allOf;
-import static java.util.EnumSet.complementOf;
-import static java.util.EnumSet.of;
-import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.toMap;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.fest.assertions.data.MapEntry.entry;
 import static org.interstellarocean.terraforming.util.CatchThrowableWorkaround.caughtThrowable;
@@ -19,11 +14,9 @@ import static org.interstellarocean.terraforming.util.TestGroups.UNIT;
 
 import java.lang.Thread.State;
 import java.util.Collection;
-import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import org.interstellarocean.terraforming.util.EnumInitUtil.SafeMapFrom;
 import org.interstellarocean.terraforming.util.EnumInitUtil.SafeMapStore;
 import org.testng.annotations.BeforeMethod;
@@ -33,7 +26,7 @@ import org.testng.annotations.Test;
  * @author Dariusz Wakuliński
  */
 @Test(groups = UNIT)
-public class EnumInitHelperTest {
+public class EnumInitHelperSafeMapTest {
 
 	private enum WaivedEnum {
 		@Unmapped WAIVED_ENUM;
@@ -56,67 +49,6 @@ public class EnumInitHelperTest {
 	@BeforeMethod
 	public void setUp() {
 		objectUnderTest = new EnumInitHelper();
-	}
-
-	public void shouldNullMappingErrorPass() {
-		// when
-		Supplier<AssertionError> result = objectUnderTest.nullMappingError(TEST_ENUM);
-
-		// then
-		assertThat(result).isNotNull();
-	}
-
-	public void shouldNullMappingErrorExplodeWhenGetCalled() {
-		// when
-		catchThrowable(objectUnderTest.nullMappingError(TEST_ENUM)).get();
-
-		// then
-		assertThat(caughtThrowable()).isExactlyInstanceOf(AssertionError.class).hasMessage("Null mapping for " + TEST_ENUM);
-	}
-
-	public void shouldAssertAllMappedPass() {
-		// given
-		EnumMap<State, String> fullMap = new EnumMap<>(allOf(State.class).stream().collect(toMap(identity(), State::name)));
-		EnumMap<State, String> fullMapCopy = fullMap.clone();
-
-		// when
-		EnumMap<State, String> result = objectUnderTest.assertAllMapped(fullMap);
-
-		// then
-		assertThat(result).isSameAs(fullMap).isEqualTo(fullMapCopy);
-	}
-
-	public void shouldAssertAllMappedExplodeForNullArgument() {
-		// given
-		EnumMap<State, ?> nullMap = null;
-
-		// when
-		catchThrowable(objectUnderTest).assertAllMapped(nullMap);
-
-		// then
-		assertThat(caughtThrowable()).isExactlyInstanceOf(AssertionError.class).hasMessage("Invalid use: null mappings argument");
-	}
-
-	public void shouldAssertAllMappedExplodeForEmptyMap() {
-		// given
-		EnumMap<State, ?> emptyMap = new EnumMap<>(State.class);
-
-		// when
-		catchThrowable(objectUnderTest).assertAllMapped(emptyMap);
-
-		// then
-		assertThat(caughtThrowable()).isExactlyInstanceOf(AssertionError.class).hasMessage("Missing all mappings for (see stack trace for type)");
-	}
-
-	public void shouldAssertAllMappedExplodeForMissingMaping() {
-		// given
-		EnumMap<State, ?> missingMap = new EnumMap<>(complementOf(of(TEST_ENUM)).stream().collect(toMap(identity(), State::name)));
-
-		// when
-		catchThrowable(objectUnderTest).assertAllMapped(missingMap);
-
-		// then
-		assertThat(caughtThrowable()).isExactlyInstanceOf(AssertionError.class).hasMessage("Missing mapping(s) for " + singleton(TEST_ENUM));
 	}
 
 	public void shouldSafeMapPass() {


### PR DESCRIPTION
EnumInitHelper: The error suppliers returns errors instead of throwing
Tests: splited for improved readability and maintainability

Resolves #18
